### PR TITLE
Adds CLI arg for wandb run notes

### DIFF
--- a/openvalidators/config.py
+++ b/openvalidators/config.py
@@ -218,6 +218,12 @@ def add_args(cls, parser):
         help="How many epochs before we force a new run.",
         default=100,
     )
+    parser.add_argument(
+        "--wandb.notes",
+        type=str,
+        help="Notes to add to the wandb run.",
+        default="",
+    )
 
     # Mocks
     parser.add_argument(

--- a/openvalidators/utils.py
+++ b/openvalidators/utils.py
@@ -51,6 +51,7 @@ def init_wandb( self, reinit=False ):
         mode='offline' if self.config.wandb.offline else 'online',
         dir=self.config.neuron.full_path,
         tags=tags,
+        notes=self.config.wandb.notes,
     )
     bt.logging.debug(str(self.wandb))
 


### PR DESCRIPTION
This is useful because it allows for improved run annotations and also it propagates the notes to all rollover runs.

![image](https://github.com/opentensor/validators/assets/6709103/b1041958-9ead-4c62-bd95-c9724d2d007e)
