### PR TITLE
fix validator crashing when trying to set weights with wandb off

### DIFF
--- a/openvalidators/weights.py
+++ b/openvalidators/weights.py
@@ -51,8 +51,10 @@ def set_weights(self):
     bt.logging.trace("processed_weights", processed_weights)
     bt.logging.trace("processed_weight_uids", processed_weight_uids)
 
+    if not self.config.wandb.off:
+        wandb.log({"set_weights": list(zip(processed_weight_uids.tolist(), processed_weights.tolist()))})
+
     # Set the weights on chain via our subtensor connection.
-    wandb.log({"set_weights": list(zip(processed_weight_uids.tolist(), processed_weights.tolist()))})
     self.subtensor.set_weights(
         wallet=self.wallet,
         netuid=self.config.netuid,


### PR DESCRIPTION
This fixes the validator crashing when attempting to set weights with wandb.off set to true