### PR TITLE
Add `--neuron.outsource_scoring`

### DIFF
--- a/openvalidators/config.py
+++ b/openvalidators/config.py
@@ -141,7 +141,7 @@ def add_args(cls, parser):
         "--neuron.scoring_sample_size",
         type=int,
         help="How many miners to query for the scoring prompt.",
-        default=10,
+        default=2,
     )
 
     parser.add_argument(
@@ -250,6 +250,12 @@ def add_args(cls, parser):
         "--neuron.nsfw_filter",
         action="store_true",
         help="If set, filter out not-safe-for-work messages.",
+        default=False,
+    )
+    parser.add_argument(
+        "--neuron.outsource_scoring",
+        action="store_true",
+        help="If set, enable outsourced scoring.",
         default=False,
     )
 

--- a/openvalidators/config.py
+++ b/openvalidators/config.py
@@ -92,7 +92,7 @@ def add_args(cls, parser):
         "--neuron.num_concurrent_forwards",
         type=int,
         help="The number of concurrent forwards running at any time.",
-        default=5,
+        default=1,
     )
     parser.add_argument(
         "--neuron.disable_set_weights",
@@ -125,7 +125,7 @@ def add_args(cls, parser):
         "--neuron.followup_sample_size",
         type=int,
         help="How many miners to query for the follow up prompt.",
-        default=10,
+        default=50,
     )
 
     parser.add_argument("--neuron.answer_timeout", type=float, help="Answer query timeout.", default=10)
@@ -133,7 +133,7 @@ def add_args(cls, parser):
         "--neuron.answer_sample_size",
         type=int,
         help="How many miners to query for the answer.",
-        default=10,
+        default=50,
     )
 
     parser.add_argument("--neuron.scoring_timeout", type=float, help="Scoring query timeout", default=10)

--- a/openvalidators/config.py
+++ b/openvalidators/config.py
@@ -92,7 +92,7 @@ def add_args(cls, parser):
         "--neuron.num_concurrent_forwards",
         type=int,
         help="The number of concurrent forwards running at any time.",
-        default=1,
+        default=5,
     )
     parser.add_argument(
         "--neuron.disable_set_weights",

--- a/openvalidators/forward.py
+++ b/openvalidators/forward.py
@@ -285,13 +285,14 @@ async def forward(self):
     best_followup = followup_completions[followup_rewards.argmax(dim=0)].strip()
 
     # Prompt-based scoring via network. Prohibits self-scoring.
-    (
-        followup_scorings,
-        followup_scoring_uids,
-        followup_scoring_completions,
-        followup_scoring_values,
-    ) = await scoring_completions(self, bootstrap_prompt, followup_scoring_template, followup_responses, followup_uids)
-    best_followup_scoring = followup_completions[followup_scorings.argmax(dim=0)].strip()
+    if self.config.neuron.outsource_scoring:
+        (
+            followup_scorings,
+            followup_scoring_uids,
+            followup_scoring_completions,
+            followup_scoring_values,
+        ) = await scoring_completions(self, bootstrap_prompt, followup_scoring_template, followup_responses, followup_uids)
+        best_followup_scoring = followup_completions[followup_scorings.argmax(dim=0)].strip()
 
     # Backward call sends reward info back to followup_uids.
     _followup_backward = await self.dendrite_pool.async_backward(
@@ -319,13 +320,14 @@ async def forward(self):
     best_answer = answer_completions[answer_rewards.argmax(dim=0)].strip()
 
     # Prompt-based scoring via network. Prohibits self-scoring.
-    (
-        answer_scorings,
-        answer_scoring_uids,
-        answer_scoring_completions,
-        answer_scoring_values,
-    ) = await scoring_completions(self, answer_prompt, answer_scoring_template, answer_responses, answer_uids)
-    best_answer_scoring = answer_completions[answer_scorings.argmax(dim=0)].strip()
+    if self.config.neuron.outsource_scoring:
+        (
+            answer_scorings,
+            answer_scoring_uids,
+            answer_scoring_completions,
+            answer_scoring_values,
+        ) = await scoring_completions(self, answer_prompt, answer_scoring_template, answer_responses, answer_uids)
+        best_answer_scoring = answer_completions[answer_scorings.argmax(dim=0)].strip()
 
     # Backward call sends reward info back to answer_uids.
     _answer_backward = await self.dendrite_pool.async_backward(
@@ -364,11 +366,6 @@ async def forward(self):
         "followup_completions": followup_completions,
         "followup_times": [comp.elapsed_time for comp in followup_responses],
         "followup_rewards": followup_rewards.tolist(),
-        "followup_scorings": followup_scorings,
-        "followup_scoring_uids": followup_scoring_uids,
-        "followup_scoring_completions": followup_scoring_completions,
-        "followup_scoring_values": followup_scoring_values,
-        "best_followup_scoring": best_followup_scoring,
         "best_followup": best_followup,
         "best_answer": best_answer,
         "answer_prompt": answer_prompt,
@@ -376,11 +373,6 @@ async def forward(self):
         "answer_completions": answer_completions,
         "answer_times": [ans.elapsed_time for ans in answer_responses],
         "answer_rewards": answer_rewards.tolist(),
-        "answer_scorings": answer_scorings,
-        "answer_scoring_uids": answer_scoring_uids,
-        "answer_scoring_completions": answer_scoring_completions,
-        "answer_scoring_values": answer_scoring_values,
-        "best_answer_scoring": best_answer_scoring,
     }
 
     if self.config.neuron.nsfw_filter:
@@ -388,6 +380,22 @@ async def forward(self):
             {
                 "followup_nsfw_scores": [is_nsfw(self, comp, return_score=True) for comp in followup_completions],
                 "answer_nsfw_scores": [is_nsfw(self, ans, return_score=True) for ans in answer_completions],
+            }
+        )
+
+    if self.config.neuron.outsource_scoring:
+        event.update(
+            {
+                "followup_scorings": followup_scorings,
+                "followup_scoring_uids": followup_scoring_uids,
+                "followup_scoring_completions": followup_scoring_completions,
+                "followup_scoring_values": followup_scoring_values,
+                "best_followup_scoring": best_followup_scoring,
+                "answer_scorings": answer_scorings,
+                "answer_scoring_uids": answer_scoring_uids,
+                "answer_scoring_completions": answer_scoring_completions,
+                "answer_scoring_values": answer_scoring_values,
+                "best_answer_scoring": best_answer_scoring,
             }
         )
 

--- a/openvalidators/utils.py
+++ b/openvalidators/utils.py
@@ -38,6 +38,8 @@ def init_wandb(self, reinit=False):
         tags.append("custom_gating_model")
     if self.config.neuron.nsfw_filter:
         tags.append("nsfw_filter")
+    if self.config.neuron.outsource_scoring:
+        tags.append("outsource_scoring")
     if self.config.neuron.disable_set_weights:
         tags.append("disable_set_weights")
 


### PR DESCRIPTION
### Add `--neuron.outsource_scoring`

By default outsourced scoring is disabled.
Enable with `--neuron.outsource_scoring`.
Adds wandb flag when enabled, omits outsourced scoring values when disabled.