### PR TITLE
Adds event schema to wandb logged data

### DIFF
--- a/openvalidators/__init__.py
+++ b/openvalidators/__init__.py
@@ -26,6 +26,7 @@ from . import reward
 from . import run
 from . import utils
 from . import weights
+from . import event
 
 __version__ = "1.0.6"
 version_split = __version__.split(".")

--- a/openvalidators/event.py
+++ b/openvalidators/event.py
@@ -1,0 +1,63 @@
+import bittensor as bt
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class EventSchema:
+    completions: List[str]  # List of completions received for a given prompt
+    name: str  # Prompt type, e.g. 'followup', 'answer'
+    block: float  # Current block at given step
+    gating_loss: float  # Gating model loss for given step
+    uids: List[int]  # Queried uids
+    prompt: str  # Prompt text string
+    step_length: float  # Elapsed time between the beginning of a run step to the end of a run step
+    best: str  # Best completion for given prompt
+
+    # Reward data
+    rewards: List[float]  # Reward vector for given step
+    dahoas_reward_model: Optional[List[float]]
+    blacklist_filter: Optional[List[float]]  # Output vector of the blacklist filter
+    nsfw_filter: Optional[List[float]]  # Output vector of the nsfw filter
+    reciprocate_reward_model: Optional[List[float]]  # Output vector of the reciprocate reward model
+    diversity_reward_model: Optional[List[float]]  # Output vector of the diversity reward model
+    rlhf_reward_model: Optional[List[float]]  # Output vector of the rlhf reward model
+    prompt_reward_model: Optional[List[float]]  # Output vector of the prompt reward model
+    relevance_scoring: Optional[List[float]]  # Output vector of the relevance scoring reward model
+
+    # Weights data
+    set_weights: Optional[List[List[float]]]
+
+    @staticmethod
+    def from_dict(event_dict: dict, should_log_rewards: bool) -> 'EventSchema':
+        """Converts a dictionary to an EventSchema object."""
+        rewards = {
+            'dahoas_reward_model': event_dict.get('dahoas_reward_model'),
+            'blacklist_filter': event_dict.get('blacklist_filter'),
+            'nsfw_filter': event_dict.get('nsfw_filter'),
+            'reciprocate_reward_model': event_dict.get('reciprocate_reward_model'),
+            'diversity_reward_model': event_dict.get('diversity_reward_model'),
+            'rlhf_reward_model': event_dict.get('rlhf_reward_model'),
+            'prompt_reward_model': event_dict.get('prompt_reward_model'),
+            'relevance_scoring': event_dict.get('relevance_scoring'),
+        }
+
+        # Logs warning that expected data was not set properly
+        if should_log_rewards and any(value is None for value in rewards.values()):
+            for key, value in rewards.items():
+                if value is None:
+                    bt.logging.warning(f'EventSchema.from_dict: {key} is None, data will not be logged')
+
+        return EventSchema(
+            completions=event_dict['completions'],
+            name=event_dict['name'],
+            block=event_dict['block'],
+            gating_loss=event_dict['gating_loss'],
+            uids=event_dict['uids'],
+            prompt=event_dict['prompt'],
+            step_length=event_dict['step_length'],
+            best=event_dict['best'],
+            rewards=event_dict['rewards'],
+            **rewards,
+            set_weights=None,
+        )

--- a/openvalidators/event.py
+++ b/openvalidators/event.py
@@ -16,7 +16,7 @@ class EventSchema:
 
     # Reward data
     rewards: List[float]  # Reward vector for given step
-    dahoas_reward_model: Optional[List[float]]
+    dahoas_reward_model: Optional[List[float]] # Output vector of the dahoas reward model
     blacklist_filter: Optional[List[float]]  # Output vector of the blacklist filter
     nsfw_filter: Optional[List[float]]  # Output vector of the nsfw filter
     reciprocate_reward_model: Optional[List[float]]  # Output vector of the reciprocate reward model

--- a/openvalidators/neuron.py
+++ b/openvalidators/neuron.py
@@ -127,19 +127,18 @@ class neuron:
         bt.logging.debug("loading", "reward_functions")
         if self.config.neuron.mock_reward_models:
             self.reward_functions = [ 
-                MockRewardModel('blacklist'), 
-                MockRewardModel('nsfw') 
+                MockRewardModel('blacklist_filter'),
+                MockRewardModel('nsfw_filter'),
             ]
             bt.logging.debug(str(self.reward_functions))
         else:
             self.reward_functions = [ 
-                Blacklist() if not self.config.neuron.blacklist_off else MockRewardModel('blacklist'),
-                NSFWRewardModel( device = self.device ) if not self.config.neuron.nsfw_off else MockRewardModel('nsfw'),
-                OpenAssistantRewardModel( device = self.device ) if not self.config.neuron.openassistant_off else MockRewardModel('openassistant'), 
-                ReciprocateRewardModel( device = self.device ) if not self.config.neuron.reciprocate_off else MockRewardModel('reciprocate'),
-                BertRelevanceRewardModel( device = self.device ) if not self.config.neuron.relevance_off else MockRewardModel('relevance'),
-                DahoasRewardModel( path = self.config.neuron.full_path, device = self.device ) if not self.config.neuron.dahoas_off else MockRewardModel('dahoas'),
-                DiversityRewardModel( device = self.device ) if not self.config.neuron.diversity_off else MockRewardModel('diversity'),
+                Blacklist() if not self.config.neuron.blacklist_off else MockRewardModel('blacklist_filter'),
+                NSFWRewardModel( device = self.device ) if not self.config.neuron.nsfw_off else MockRewardModel('nsfw_filter'),
+                OpenAssistantRewardModel( device = self.device ) if not self.config.neuron.openassistant_off else MockRewardModel('rlhf_reward_model'),
+                BertRelevanceRewardModel( device = self.device ) if not self.config.neuron.relevance_off else MockRewardModel('relevance_scoring'),
+                DahoasRewardModel( path = self.config.neuron.full_path, device = self.device ) if not self.config.neuron.dahoas_off else MockRewardModel('dahoas_reward_model'),
+                DiversityRewardModel( device = self.device ) if not self.config.neuron.diversity_off else MockRewardModel('diversity_reward_model'),
             ]
             bt.logging.debug(str(self.reward_functions))
 

--- a/openvalidators/neuron.py
+++ b/openvalidators/neuron.py
@@ -139,11 +139,11 @@ class neuron:
                 Blacklist() if not self.config.neuron.blacklist_off else MockRewardModel('blacklist_filter'),
                 NSFWRewardModel( device = self.device ) if not self.config.neuron.nsfw_off else MockRewardModel('nsfw_filter'),
                 OpenAssistantRewardModel( device = self.device ) if not self.config.neuron.openassistant_off else MockRewardModel('rlhf_reward_model'),
-                ReciprocateRewardModel( device = self.device ) if not self.config.neuron.reciprocate_off else MockRewardModel('reciprocate'),
+                ReciprocateRewardModel( device = self.device ) if not self.config.neuron.reciprocate_off else MockRewardModel('reciprocate_reward_model'),
                 BertRelevanceRewardModel( device = self.device ) if not self.config.neuron.relevance_off else MockRewardModel('relevance_scoring'),
                 DahoasRewardModel( path = self.config.neuron.full_path, device = self.device ) if not self.config.neuron.dahoas_off else MockRewardModel('dahoas_reward_model'),
                 DiversityRewardModel( device = self.device ) if not self.config.neuron.diversity_off else MockRewardModel('diversity_reward_model'),
-                PromptRewardModel( device = self.device ) if not self.config.neuron.prompt_based_off else MockRewardModel('prompt'),
+                PromptRewardModel( device = self.device ) if not self.config.neuron.prompt_based_off else MockRewardModel('prompt_reward_model'),
             ]
             bt.logging.debug(str(self.reward_functions))
 

--- a/openvalidators/reward/blacklist.py
+++ b/openvalidators/reward/blacklist.py
@@ -24,7 +24,7 @@ blacklist = ["That is an excellent question."]
 class Blacklist( BaseRewardModel ):
 
     @property
-    def name(self) -> str: return "blacklist"
+    def name(self) -> str: return "blacklist_filter"
 
     def reward( self, prompt: str, completion: str ) -> float:
         if completion in blacklist: return 0.0

--- a/openvalidators/reward/dahoas.py
+++ b/openvalidators/reward/dahoas.py
@@ -28,7 +28,7 @@ class DahoasRewardModel( BaseRewardModel ):
     model_name = "EleutherAI/gpt-j-6b"
 
     @property
-    def name(self) -> str: return "dahoas-reward-model"
+    def name(self) -> str: return "dahoas_reward_model"
 
     @staticmethod
     def load_weights( path: str ):

--- a/openvalidators/reward/diversity.py
+++ b/openvalidators/reward/diversity.py
@@ -45,12 +45,9 @@ def mean_pooling( model_output, attention_mask ):
     )
     
 class DiversityRewardModel( BaseRewardModel ):
-
     relevance_model_path = "bert-base-uncased"
-
-
     @property
-    def name(self) -> str: return "diversity-reward-function"
+    def name(self) -> str: return "diversity_reward_model"
 
     def __init__( self, device: str ):
         super().__init__()

--- a/openvalidators/reward/nsfw.py
+++ b/openvalidators/reward/nsfw.py
@@ -26,7 +26,7 @@ class NSFWRewardModel( BaseRewardModel ):
     nsfw_filter_model_path = "facebook/roberta-hate-speech-dynabench-r4-target"
 
     @property
-    def name(self) -> str: return "nsfw-filter"
+    def name(self) -> str: return "nsfw_filter"
    
     def __init__( self, device: str ):
         super().__init__()

--- a/openvalidators/reward/open_assistant.py
+++ b/openvalidators/reward/open_assistant.py
@@ -24,7 +24,7 @@ class OpenAssistantRewardModel( BaseRewardModel ):
     reward_model_name: str = "OpenAssistant/reward-model-deberta-v3-large-v2"
 
     @property
-    def name(self) -> str: return "openassistant-reward-model"
+    def name(self) -> str: return "rlhf_reward_model"
 
     def __init__( self , device: str ):
         super().__init__()

--- a/openvalidators/reward/prompt.py
+++ b/openvalidators/reward/prompt.py
@@ -26,7 +26,7 @@ class PromptRewardModel(BaseRewardModel):
     reward_model_name: str = "VMware/open-llama-7b-open-instruct"
 
     @property
-    def name(self) -> str: return "prompt-reward-model"
+    def name(self) -> str: return "prompt_reward_model"
 
     def __init__(self, device: str):
         super().__init__()

--- a/openvalidators/reward/reciprocate.py
+++ b/openvalidators/reward/reciprocate.py
@@ -27,7 +27,7 @@ class ReciprocateRewardModel( BaseRewardModel ):
     revision: str = "501f895"
 
     @property
-    def name(self) -> str: return "reciprocate-reward-model"
+    def name(self) -> str: return "reciprocate_reward_model"
 
     def __init__( self, device: str ):
         super().__init__()

--- a/openvalidators/reward/relevance.py
+++ b/openvalidators/reward/relevance.py
@@ -25,7 +25,7 @@ class BertRelevanceRewardModel( BaseRewardModel ):
     relevance_model_path = "bert-base-uncased"
 
     @property
-    def name(self) -> str: return "bert-embedding-relevance-scoring"
+    def name(self) -> str: return "relevance_scoring"
    
     def __init__( self, device: str ):
         super().__init__()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bittensor==5.1.0
-transformers==4.30.0
+transformers
 wandb==0.15.3
 datasets==2.12.0
 plotly==5.14.1

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,143 @@
+# The MIT License (MIT)
+# Copyright © 2021 Yuma Rao
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+import unittest
+from dataclasses import fields
+from unittest.mock import patch
+from openvalidators.event import EventSchema
+
+class EventTestCase(unittest.TestCase):
+
+    def test_event_from_dict_all_forward_columns_match(self):
+        """Test that all default columns logged on the forward pass are correctly converted
+        """
+        # Arrange: Create a dictionary with all columns
+        event_dict = {
+            'completions': ['test'],
+            'name': 'test-name',
+            'block': 1.0,
+            'gating_loss': 1.0,
+            'uids': [1],
+            'prompt': 'test-prompt',
+            'step_length': 1.0,
+            'best': 'test-best',
+            'rewards': [1.0],
+            'dahoas_reward_model': [1.0],
+            'blacklist_filter': [1.0],
+            'nsfw_filter': [1.0],
+            'reciprocate_reward_model': [1.0],
+            'diversity_reward_model': [1.0],
+            'rlhf_reward_model': [1.0],
+            'prompt_reward_model': [1.0],
+            'relevance_scoring': [1.0],
+        }
+
+        # Act
+        with patch('bittensor.logging.warning') as mock_warning:
+            event = EventSchema.from_dict(event_dict, should_log_rewards=True)
+            mock_warning.assert_not_called()
+
+        # Assert
+        for field in fields(EventSchema):
+            field_name = field.name
+            field_value = getattr(event, field_name)
+
+            # Note: Does not include 'set_weights' column as it is not logged on the forward pass
+            if field_name == 'set_weights':
+                assert field_value is None
+                continue
+
+            print(field_name, field_value)
+            assert field_name in event_dict and event_dict[field_name] == field_value
+
+
+    def test_event_from_dict_forward_no_reward_logging(self):
+        """Test that all default columns (not including reward columns) logged on the forward pass are
+        correctly converted"""
+        # Assert: create a dictionary with all non-related reward columns
+        event_dict = {
+            'completions': ['test'],
+            'name': 'test-name',
+            'block': 1.0,
+            'gating_loss': 1.0,
+            'uids': [1],
+            'prompt': 'test-prompt',
+            'step_length': 1.0,
+            'best': 'test-best',
+            'rewards': [1.0],
+        }
+
+        # Act
+        with patch('bittensor.logging.warning') as mock_warning:
+            event = EventSchema.from_dict(event_dict, should_log_rewards=False)
+            mock_warning.assert_not_called()
+
+        # Assert: Check that all columns that were logged are correctly converted
+        for key, value in event_dict.items():
+            assert getattr(event, key) == value
+
+        # Assert: Check that all reward columns that are not logged are set to None
+        assert event.set_weights is None
+        assert event.dahoas_reward_model is None
+        assert event.blacklist_filter is None
+        assert event.nsfw_filter is None
+        assert event.reciprocate_reward_model is None
+        assert event.diversity_reward_model is None
+        assert event.rlhf_reward_model is None
+        assert event.prompt_reward_model is None
+        assert event.relevance_scoring is None
+
+    def test_event_from_dict_forward_reward_logging_mismatch(self):
+        """Test that all default columns logged on the forward pass are correctly converted and that
+        that reward columns that should be logged are logged as warnings"""
+        # Assert: create a dictionary with all non-related reward columns
+        event_dict = {
+            'completions': ['test'],
+            'name': 'test-name',
+            'block': 1.0,
+            'gating_loss': 1.0,
+            'uids': [1],
+            'prompt': 'test-prompt',
+            'step_length': 1.0,
+            'best': 'test-best',
+            'rewards': [1.0],
+        }
+
+        not_logged_columns = ['dahoas', 'blacklist_filter', 'nsfw_filter', 'reciprocate_reward_model',
+                              'diversity_reward_model', 'rlhf_reward_model', 'prompt_reward_model',
+                              'relevance_scoring']
+
+        # Act
+        with patch('bittensor.logging.warning') as mock_warning:
+            event = EventSchema.from_dict(event_dict, should_log_rewards=True)
+            # Assert: Check that all columns that are not logged in the dict are logged as warnings
+            self.assertEqual(mock_warning.call_count, len(not_logged_columns))
+
+        # Assert: Check that all columns that were logged are correctly converted
+        for key, value in event_dict.items():
+            assert getattr(event, key) == value
+
+        # Assert: Check that all reward columns that are not logged are set to None
+        assert event.set_weights is None
+        assert event.dahoas_reward_model is None
+        assert event.blacklist_filter is None
+        assert event.nsfw_filter is None
+        assert event.reciprocate_reward_model is None
+        assert event.diversity_reward_model is None
+        assert event.rlhf_reward_model is None
+        assert event.prompt_reward_model is None
+        assert event.relevance_scoring is None
+


### PR DESCRIPTION
This PR seeks to bring more consistency regarding the data that is sent to wandb. Having a known structured class facilitates the development of downstream tasks besides bringing transparency to what data is actually being sent to wandb. 

The idea is to centralize the log definition into a single place, so it's easier to evolve and maintain

- adds event schema structure
- adds unit tests to schema code
- normalizes reward stack components naming