### PR TITLE
Adds circuit breaker to auto_run file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+app.config.js

--- a/run.sh
+++ b/run.sh
@@ -209,8 +209,8 @@ echo "module.exports = {
     name   : '$proc_name',
     script : '$script',
     interpreter: 'python3',
-    min_uptime: '2m',
-    max_restarts: '3',
+    min_uptime: '5m',
+    max_restarts: '5',
     args: [$joined_args]
   }]
 }" > app.config.js


### PR DESCRIPTION
## Problem:

The current `run.sh` script auto-restarts the openvalidators indefinitely, that in the circunstance of a broken validator, causes repeated problematic runs systematically in a non-stop mode. This brings several inconveniences, such as:
- Lack of vision of the real state of the application from the user perspective
- Data pollution in wandb 
- Waste of energy and resources

Bellow some data on the current state of openvalidator 1.0.8 wandb runs:
- Total runs: 2328
- Total problematic runs: 2108 (90.55% of all runs of version 1.0.8)
- Out of all the problematic runs, 2097 (99%) were generated from 4 users that were/are auto-running a broken validator. 

## Proposed solution:
A circuit breaker can be added using a [pm2 configuration file](https://pm2.keymetrics.io/docs/usage/application-declaration/) by defining the following `app.config.js`:
```js
module.exports = {
  apps : [{
    name   : '$proc_name', //Process name
    script : '$script',  //Script to be used
    interpreter: 'python3', // Python interpreter
    min_uptime: '5m', // min uptime of the app to be considered started
    max_restarts: '5', //number of consecutive unstable restarts (min_uptime) before app is considered errored
    args: [$joined_args]
  }]
}" 
```
where if pm2 fails `max_restarts` (5) times where each execution attempt lasted less than `min_uptime` (5 minutes), the process is considered ``errored`` and the auto-restart stops.

> Note: I wish I could just add `--min_uptime` to the existing cli command of pm2 but it seems that it's not supported accordingly to this issues in the PM 2 repo: [4162](https://github.com/Unitech/pm2/issues/4162), [2877](https://github.com/Unitech/pm2/issues/2877). So the only usage of this feature that I found was through the use of a `config.js` file 
 
