### PR TITLE
Adds track gating model flag

### DIFF
--- a/openvalidators/config.py
+++ b/openvalidators/config.py
@@ -213,6 +213,12 @@ def add_args(cls, parser):
         help="Notes to add to the wandb run.",
         default="",
     )
+    parser.add_argument(
+        "--wandb.track_gating_model",
+        action="store_true",
+        help="Track the model weights of the gating model in wandb.",
+        default=False,
+    )
 
     # Mocks
     parser.add_argument("--mock", action="store_true", help="Mock all items.", default=False)

--- a/openvalidators/utils.py
+++ b/openvalidators/utils.py
@@ -193,7 +193,7 @@ def save_state(self):
         gating_model_file_path = f"{self.config.neuron.full_path}/{gating_model_name}_gating_linear_layer.pth"
         torch.save(gating_model_linear_layer_dict, gating_model_file_path)
 
-        if not self.config.wandb.off:
+        if not self.config.wandb.off and self.config.wandb.track_gating_model:
             model_artifact = wandb.Artifact(f"{gating_model_name}_gating_linear_layer", type="model")
             model_artifact.add_file(gating_model_file_path)
             self.wandb.log_artifact(model_artifact)


### PR DESCRIPTION
### Problem:
Currently, a new artifact (last linear layer model weights of gating model) is created every time the validator sets weights in the network, for every openvalidator.

This leads to thousands of redundant models that consumes a lot of storage in wandb. 

### Proposed solution:
Since the model weights are not being used, one efficient way to fix that is to put a simple flag to track weights that defaults to false. That way the model tracking is only created when user explicitly defines it.

> **Note:** There are ways to work around wandb to control the run in a way that only one model per run is saved, but that solution is not natural to this feature, as versioning is the default expected behavior of wandb in terms of tracking. 

This PR closes #34 
