### PR TITLE
Refine diversity model

### DIFF
--- a/openvalidators/reward/diversity.py
+++ b/openvalidators/reward/diversity.py
@@ -45,7 +45,7 @@ def mean_pooling( model_output, attention_mask ):
     
 class DiversityRewardModel( BaseRewardModel ):
     
-    relevance_model_path = "sentence-transformers/all-mpnet-base-v2"
+    diversity_model_path = "sentence-transformers/all-mpnet-base-v2"
     
     @property
     def name(self) -> str: return RewardModelType.diversity.value
@@ -53,13 +53,13 @@ class DiversityRewardModel( BaseRewardModel ):
     def __init__( self, device: str ):
         super().__init__()
         self.device = device
-        self.tokenizer = AutoTokenizer.from_pretrained( DiversityRewardModel.relevance_model_path )
-        self.model = AutoModel.from_pretrained( DiversityRewardModel.relevance_model_path ).to(self.device)
+        self.tokenizer = AutoTokenizer.from_pretrained( DiversityRewardModel.diversity_model_path )
+        self.model = AutoModel.from_pretrained( DiversityRewardModel.diversity_model_path ).to(self.device)
 
     def get_embeddings( self, sentences: List[str] ) -> "torch.FloatTensor":
         """Runs a forward pass through the model.
         Args:
-            message (:obj:`str`):
+            sentences (:obj:`List[str]`):
                 text message to be encoded.
         Returns:
             embedding (:obj:`torch.FloatTensor`):

--- a/openvalidators/reward/diversity.py
+++ b/openvalidators/reward/diversity.py
@@ -88,7 +88,7 @@ class DiversityRewardModel( BaseRewardModel ):
     def get_rewards( self, prompt: str, completions: List[str], name: str ) -> torch.FloatTensor:
 
         # Get embeddings for all completions.
-        embeddings = self.get_embedding( completions )
+        embeddings = self.get_embeddings( completions )
 
         # Calculate the pairwise cosine similarity.
         similarity = pairwise_cosine_similarity( embeddings, embeddings )

--- a/openvalidators/reward/diversity.py
+++ b/openvalidators/reward/diversity.py
@@ -16,6 +16,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 import torch
+import torch.nn.functional as F
 from typing import List
 from .config import RewardModelType
 from .reward import BaseRewardModel
@@ -37,15 +38,15 @@ def mean_pooling( model_output, attention_mask ):
             and dividing it by the sum of input_mask_expanded after clamping its values to a minimum of 1e-9.
     """
     token_embeddings = model_output[0]
-    input_mask_expanded = (
-        attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
-    )
+    input_mask_expanded = attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
     return torch.sum(token_embeddings * input_mask_expanded, 1) / torch.clamp(
         input_mask_expanded.sum(1), min=1e-9
     )
     
 class DiversityRewardModel( BaseRewardModel ):
-    relevance_model_path = "bert-base-uncased"
+    
+    relevance_model_path = "sentence-transformers/all-mpnet-base-v2"
+    
     @property
     def name(self) -> str: return RewardModelType.diversity.value
 
@@ -55,7 +56,7 @@ class DiversityRewardModel( BaseRewardModel ):
         self.tokenizer = AutoTokenizer.from_pretrained( DiversityRewardModel.relevance_model_path )
         self.model = AutoModel.from_pretrained( DiversityRewardModel.relevance_model_path ).to(self.device)
 
-    def get_embedding( self, message: str ) -> "torch.FloatTensor":
+    def get_embeddings( self, sentences: List[str] ) -> "torch.FloatTensor":
         """Runs a forward pass through the model.
         Args:
             message (:obj:`str`):
@@ -64,38 +65,35 @@ class DiversityRewardModel( BaseRewardModel ):
             embedding (:obj:`torch.FloatTensor`):
                 Embedding for the message.
         """
+        # Tokenizing sentences
         encoded_input = self.tokenizer(
-            message,
+            sentences,
             padding=True,
             truncation=True,
-            return_overflowing_tokens=True,
             return_tensors="pt",
         ).to(self.device)
 
-        # Pop the overflow mapping from the input to maintain the expected { input_ids, mask } format of the model
-        _ = encoded_input.pop("overflow_to_sample_mapping")
-
+        # Compute token embedding
         with torch.no_grad():
             embeddings = self.model(**encoded_input)
 
+        # Pooling
         sentence_embeddings = mean_pooling(embeddings, encoded_input["attention_mask"])
-        sentence_embeddings = torch.nn.functional.normalize(sentence_embeddings, p=2, dim=1)
-        batch_representation = torch.mean(sentence_embeddings, dim=0)
-        return batch_representation
+        
+        # Normalizing
+        sentence_embeddings = F.normalize(sentence_embeddings, p=2, dim=1)
+        return sentence_embeddings
 
     def get_rewards( self, prompt: str, completions: List[str], name: str ) -> torch.FloatTensor:
 
         # Get embeddings for all completions.
-        embeddings = torch.stack( [ self.get_embedding( completion ) for completion in completions ] )
+        embeddings = self.get_embedding( completions )
 
         # Calculate the pairwise cosine similarity.
         similarity = pairwise_cosine_similarity( embeddings, embeddings )
 
-        # Calculate the columnwise mean.
-        mean_similarity = torch.mean( similarity, dim = 0 )
-
-        # Divide each element by the mean.
-        rewards = 1 - ( mean_similarity / torch.mean( mean_similarity ) )
+        # Reward to be at the 10% quantile of the 1 - similarity score.
+        rewards = (1 - similarity).quantile(torch.tensor(0.1).to(self.device), dim = 1 )
 
         # Return all
         return rewards

--- a/openvalidators/reward/diversity.py
+++ b/openvalidators/reward/diversity.py
@@ -55,7 +55,8 @@ class DiversityRewardModel( BaseRewardModel ):
         self.device = device
         self.tokenizer = AutoTokenizer.from_pretrained( DiversityRewardModel.diversity_model_path )
         self.model = AutoModel.from_pretrained( DiversityRewardModel.diversity_model_path ).to(self.device)
-
+        self.reward_quantile = torch.tensor(0.1).to(self.device)
+        
     def get_embeddings( self, sentences: List[str] ) -> "torch.FloatTensor":
         """Runs a forward pass through the model.
         Args:
@@ -93,7 +94,7 @@ class DiversityRewardModel( BaseRewardModel ):
         similarity = pairwise_cosine_similarity( embeddings, embeddings )
 
         # Reward to be at the 10% quantile of the 1 - similarity score.
-        rewards = (1 - similarity).quantile(torch.tensor(0.1).to(self.device), dim = 1 )
+        rewards = (1 - similarity).quantile(self.reward_quantile, dim = 1 )
 
         # Return all
         return rewards


### PR DESCRIPTION
## Model update and benchmarking result
- Changed the embedding mode from bert_base_uncased to "sentence-transformers/all-mpnet-base-v2"

[fig 1]
![SNLI_dataset](https://github.com/opentensor/validators/assets/49876827/15b40ef0-6b10-4f20-9054-ed227b561474)
- here shows the similarity scores from mpnet and bert_base model respectively on the [SNLI dataset](https://huggingface.co/datasets/snli), which focuses on recognizing textual entailment
- label 0 (green) refers to entailment sentences; label 2 (blue) refers to contradiction;  and label 1 (red) refers to contradiction
- mpnet is outperforming bert_base in classifying the 2 (entailment VS contradiction) classes with threshold at ~0.5
- bert_base is failing at giving us clearity in the difference in the dataset

[fig 2]
![c4_200m_dataset](https://github.com/opentensor/validators/assets/49876827/1b36a1e6-8769-4143-a644-4db34d88c3e7)
- it shows the benchmark result from mpnet and bert_base model respectively on the [c4 200m dataset](https://huggingface.co/datasets/liweili/c4_200m), which focuses on grammatical error correction (GEC) tasks, so that it can help us see the sensitivity of the model on some slight changes of the sentences. The less sensitive it is the better.
- note that although it seems that the model scoring are more diversed in mpnet, all of the values are larger then the TH we have set in fig 1 (> 0.5), so those should be deemed as relevent to each other, so mpnet is accurate in this case. 

[fig 3]
![foundation_validator_run](https://github.com/opentensor/validators/assets/49876827/3dcc0544-8625-4e4c-9d89-8c7560bab281)
- it shows the benchmark result from mpnet and bert_base model respectively on a validator run 
- mpnet is giving a more diversified score then bert_base

## Similarity reward conversion
- Changed the scoring from mean difference to 10% quantile, meaning that the diversity reward score would be lowered if your response is the same as 10% of the network. 
This PR here changes the the conversion of similarity to reward
From:
```python
1 - ( mean_similarity / torch.mean( mean_similarity ) )
```
To:
```python
(1 - similarity).quantile(0.1, dim = 1 )
```
For the following reasons
- Taking mean may not be good because if all peers are controlled by the same group, then they can easily separate themselves into 2 groups and response with 2 very different sentences in each group,
- Taking min may not be good because I think we still have to reserve some possibility where a honest server can still have about the same response with the rest of the network.
- So, if we take a quantile at 0.1 (adjustable), then their response can only be repeated with 10% of the network to maximise their diversity reward. So it could be a better approach then mean/min
