### PR TITLE
fix gating model tokenizer + fix wandb reward model tags

### DIFF
--- a/openvalidators/gating.py
+++ b/openvalidators/gating.py
@@ -142,6 +142,7 @@ class GatingModel(BaseGatingModel):
         self.num_uids = config.gating.num_uids
         self.device = torch.device(self.config.neuron.device)
         self.tokenizer = AutoTokenizer.from_pretrained(self.config.gating.model_name)
+        self.tokenizer.pad_token = self.tokenizer.eos_token
         self.model = AutoModel.from_pretrained(self.config.gating.model_name)
         self.linear = torch.nn.Linear(self.model.config.hidden_size, config.gating.num_uids)
         self.optimizer = torch.optim.SGD(
@@ -177,6 +178,7 @@ class GatingModel(BaseGatingModel):
         encoded_input = self.tokenizer(
             message,
             truncation=True,
+            padding=True,
             return_overflowing_tokens=True,
             return_tensors="pt",
         ).to(self.device)

--- a/openvalidators/utils.py
+++ b/openvalidators/utils.py
@@ -22,6 +22,7 @@ import copy
 import bittensor as bt
 import openvalidators
 from openvalidators.misc import ttl_get_block
+from openvalidators.reward import MockRewardModel
 
 
 def should_reinit_wandb(self):
@@ -37,7 +38,8 @@ def init_wandb(self, reinit=False):
     if self.config.neuron.use_custom_gating_model:
         tags.append("custom_gating_model")
     for fn in self.reward_functions:
-        tags.append( str(fn.name) )
+        if not isinstance(fn, MockRewardModel):
+            tags.append(str(fn.name))
     if self.config.neuron.disable_set_weights:
         tags.append("disable_set_weights")
 


### PR DESCRIPTION
The run started yesterday broke several times with the message:
```
ValueError: Unable to create tensor, you should probably activate truncation
and/or padding with 'padding=True' 'truncation=True' to have batched tensors
with the same length. Perhaps your features (`input_ids` in this case) have
excessive nesting (inputs type `list` where type `int` is expected).
During handling of the above exception, another exception occurred:
```
https://wandb.ai/opentensor-dev/openvalidators/runs/j1n1rbcl/logs?workspace=user-

The same error can be simulated by passing an input > 2048 (context window of gating model gpt-neo). 

This PR proposes the fix to this problem by adding `padding=True` and setting the eos token as default `pad_token` on model initialization (required, otherwise we get another exception)

This PR also proposes a fix for the reward model tags in wandb, as they were being logged incorrectly.