### PR TITLE
Set default reward weights

### DIFF
--- a/openvalidators/reward/config.py
+++ b/openvalidators/reward/config.py
@@ -35,8 +35,8 @@ class DefaultRewardFrameworkConfig:
     """Reward framework default configuration.
     Note: All the weights should add up to 1.0.
     """
-    rlhf_model_weight: float = 1.0
-    reciprocate_model_weight: float = 0
+    rlhf_model_weight: float = 0.5
+    reciprocate_model_weight: float = 0.3
     dahoas_model_weight: float = 0
-    diversity_model_weight: float = 0
+    diversity_model_weight: float = 0.2
     prompt_model_weight: float = 0


### PR DESCRIPTION
### Set default reward weights

```python
    rlhf_model_weight: float = 0.5
    reciprocate_model_weight: float = 0.3
    dahoas_model_weight: float = 0
    diversity_model_weight: float = 0.2
    prompt_model_weight: float = 0
```