### PR TITLE
update reqs to include proper numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pre-commit==3.3.2
 click==8.1.3
 torchmetrics
 sentencepiece
+numpy==1.21.6


### PR DESCRIPTION
Solves `np.int` error.  This was deprecated in a more recent version of numpy.

```
112 2023-06-29 21:02:35.454 |      ERROR       | Error in training loop        module 'numpy' has no attribute 'int'.
113 `np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information. 
```