### PR TITLE
Use subtensor for meta sync

### DIFF
--- a/openvalidators/neuron.py
+++ b/openvalidators/neuron.py
@@ -93,7 +93,8 @@ class neuron:
 
         # Init metagraph.
         bt.logging.debug("loading", "metagraph")
-        self.metagraph = bt.metagraph(netuid=self.config.netuid, network=self.subtensor.network)
+        self.metagraph = bt.metagraph(netuid=self.config.netuid, network=self.subtensor.network, sync=False) # Make sure not to sync without passing subtensor
+        self.metagraph.sync(subtensor=self.subtensor) # Sync metagraph with subtensor.
         self.hotkeys = copy.deepcopy(self.metagraph.hotkeys)
         bt.logging.debug(str(self.metagraph))
 

--- a/openvalidators/neuron.py
+++ b/openvalidators/neuron.py
@@ -62,6 +62,10 @@ class neuron:
     def run(self):
         run(self)
 
+    subtensor: "bt.subtensor"
+    wallet: "bt.wallet"
+    metagraph: "bt.metagraph"
+
     def __init__(self):
         self.config = neuron.config()
         self.check_config(self.config)

--- a/openvalidators/utils.py
+++ b/openvalidators/utils.py
@@ -89,7 +89,7 @@ def resync_metagraph(self: 'openvalidators.neuron.neuron'):
     previous_metagraph = copy.deepcopy(self.metagraph)
 
     # Sync the metagraph.
-    self.metagraph.sync()
+    self.metagraph.sync(subtensor=self.subtensor)
 
     # Check if the metagraph axon info has changed.
     metagraph_axon_info_updated = previous_metagraph.axons != self.metagraph.axons

--- a/openvalidators/utils.py
+++ b/openvalidators/utils.py
@@ -81,7 +81,7 @@ def checkpoint(self):
     save_state(self)
 
 
-def resync_metagraph(self):
+def resync_metagraph(self: 'openvalidators.neuron.neuron'):
     """Resyncs the metagraph and updates the hotkeys and moving averages based on the new metagraph."""
     bt.logging.info("resync_metagraph()")
 


### PR DESCRIPTION
See https://github.com/opentensor/bittensor/pull/1423

This fixes issues with the validator ignoring subtensor config args.