### PR TITLE
fixes broken Dataset init without proper default

### DIFF
--- a/openvalidators/config.py
+++ b/openvalidators/config.py
@@ -288,6 +288,13 @@ def add_args(cls, parser):
         default=False,
     )
     parser.add_argument(
+        "--neuron.redpajama_dataset_type",
+        type=str,
+        help="The dataset type to use for redpajama.",
+        choices=['default', 'arxiv', 'book', 'c4', 'common_crawl', 'github', 'stackexchange', 'wikipedia'],
+        default='default',
+    )
+    parser.add_argument(
         "--neuron.use_custom_gating_model",
         action="store_true",
         help="Use a custom gating model.",

--- a/openvalidators/dataset.py
+++ b/openvalidators/dataset.py
@@ -21,11 +21,11 @@ from datasets import load_dataset
 from collections.abc import Iterator
 
 class Dataset(Iterator):
-    def __init__(self):
+    def __init__(self, redpajama_dataset_type):
         super().__init__()
         seed = random.randint(0,1000)
         self.openwebtext = iter( load_dataset("openwebtext", split="train", streaming=True).shuffle(seed=seed, buffer_size=10000) )
-        self.red_pajama = iter( load_dataset("togethercomputer/RedPajama-Data-1T", split='train', streaming=True).shuffle(seed=seed, buffer_size=10000) )
+        self.red_pajama = iter( load_dataset("togethercomputer/RedPajama-Data-1T", redpajama_dataset_type, split='train', streaming=True).shuffle(seed=seed, buffer_size=10000) )
 
     def __next__(self):
         if random.random() < 0.5:

--- a/openvalidators/neuron.py
+++ b/openvalidators/neuron.py
@@ -103,7 +103,7 @@ class neuron:
         if self.config.neuron.mock_dataset:
             self.dataset = MockDataset()
         else:
-            self.dataset = Dataset()
+            self.dataset = Dataset(redpajama_dataset_type=self.config.neuron.redpajama_dataset_type)
         bt.logging.debug(str(self.dataset))
 
         # Init the gating model which learns which miners to select for each query.


### PR DESCRIPTION
This ensures a fresh install from `main` works as intended.

Issue: loading redpajama dataset breaks without 2nd argument for `dataset_type`.

Solution: provide a command line argument with a default in the config, set as `default`.