### PR TITLE
Diversity filter model

### DIFF
--- a/openvalidators/__init__.py
+++ b/openvalidators/__init__.py
@@ -28,6 +28,6 @@ from . import utils
 from . import weights
 from . import event
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/openvalidators/config.py
+++ b/openvalidators/config.py
@@ -236,6 +236,12 @@ def add_args(cls, parser):
         help="Dont apply the relevance reward model",
         default=False,
     )
+    parser.add_argument(
+        "--neuron.diversity_off",
+        action="store_true",
+        help="Dont apply the diversity reward model",
+        default=False,
+    )    
 
     parser.add_argument(
         "--reward.reciprocate_weight",
@@ -248,12 +254,6 @@ def add_args(cls, parser):
         type=float,
         help="Weight for the rlhf reward model",
         default=DefaultRewardFrameworkConfig.rlhf_model_weight,
-    )
-    parser.add_argument(
-        "--reward.diversity_weight",
-        type=float,
-        help="Weight for the diversity reward model",
-        default=DefaultRewardFrameworkConfig.diversity_model_weight,
     )
     parser.add_argument(
         "--reward.dahoas_weight",

--- a/openvalidators/config.py
+++ b/openvalidators/config.py
@@ -82,12 +82,11 @@ def add_args(cls, parser):
         default="cuda" if torch.cuda.is_available() else "cpu",
     )
     parser.add_argument(
-        "--neuron.log_rewards",
+        "--neuron.disable_log_rewards",
         action="store_true",
-        help="Turn on reward logging, logs all reward functions and their values to wandb.",
+        help="Disable all reward logging, suppresses reward functions and their values from being logged to wandb.",
         default=False,
     )
-
 
     parser.add_argument(
         "--neuron.num_concurrent_forwards",
@@ -130,9 +129,9 @@ def add_args(cls, parser):
     )
     parser.add_argument(
         "--neuron.num_followup_steps",
-        type = int,
-        help = "How many followup steps to take.",
-        default = 4,
+        type=int,
+        help="How many followup steps to take.",
+        default=4,
     )
 
     parser.add_argument(
@@ -293,6 +292,7 @@ def add_args(cls, parser):
         help="Use a custom gating model.",
         default=False,
     )
+
 
 def config(cls):
     parser = argparse.ArgumentParser()

--- a/openvalidators/event.py
+++ b/openvalidators/event.py
@@ -49,7 +49,7 @@ class EventSchema:
     set_weights: Optional[List[List[float]]]
 
     @staticmethod
-    def from_dict(event_dict: dict, should_log_rewards: bool) -> 'EventSchema':
+    def from_dict(event_dict: dict, disable_log_rewards: bool) -> 'EventSchema':
         """Converts a dictionary to an EventSchema object."""
         rewards = {
             'dahoas_reward_model': event_dict.get(RewardModelType.dahoas.value),
@@ -63,7 +63,7 @@ class EventSchema:
         }
 
         # Logs warning that expected data was not set properly
-        if should_log_rewards and any(value is None for value in rewards.values()):
+        if not disable_log_rewards and any(value is None for value in rewards.values()):
             for key, value in rewards.items():
                 if value is None:
                     bt.logging.warning(f'EventSchema.from_dict: {key} is None, data will not be logged')

--- a/openvalidators/forward.py
+++ b/openvalidators/forward.py
@@ -130,7 +130,7 @@ async def run_step(self, prompt: str, k: int, timeout: float, name: str, exclude
         logger.log("EVENTS", "events", **event)
 
     # Log the event to wandb.
-    wandb_event = EventSchema.from_dict(event, self.config.neuron.log_rewards)
+    wandb_event = EventSchema.from_dict(event, self.config.neuron.disable_log_rewards)
     if not self.config.wandb.off:
         self.wandb.log(asdict(wandb_event))
 

--- a/openvalidators/forward.py
+++ b/openvalidators/forward.py
@@ -30,6 +30,7 @@ from openvalidators.misc import ttl_get_block
 from openvalidators.prompts import followup_prompt, answer_prompt, augment_prompt
 from openvalidators.utils import check_uid_availability
 
+
 def get_random_uids(self, k: int, exclude: List[int] = None) -> torch.LongTensor:
     """Returns k available random uids from the metagraph.
     Args:
@@ -53,22 +54,23 @@ def get_random_uids(self, k: int, exclude: List[int] = None) -> torch.LongTensor
     uids = torch.tensor(random.sample(available_uids.tolist(), k), dtype=torch.int64)
     return uids
 
-async def run_step( self, prompt: str, k: int, timeout: float, name: str, exclude: list = []):
-    bt.logging.debug( "run_step", name )
+
+async def run_step(self, prompt: str, k: int, timeout: float, name: str, exclude: list = []):
+    bt.logging.debug("run_step", name)
 
     # Record event start time.
-    event = {'name': name}
+    event = {"name": name}
     start_time = time.time()
 
     # Get the list of uids to query for this step.
-    uids = get_random_uids( self, k = k , exclude=exclude).to(self.device)
+    uids = get_random_uids(self, k=k, exclude=exclude).to(self.device)
 
     # Make calls to the network with the prompt.
-    responses: List[ bt.DendriteCall ] = await self.dendrite_pool.async_forward( 
-        uids = uids,
-        roles = [ "user" ],
-        messages = [ prompt ],
-        timeout = timeout,
+    responses: List[bt.DendriteCall] = await self.dendrite_pool.async_forward(
+        uids=uids,
+        roles=["user"],
+        messages=[prompt],
+        timeout=timeout,
     )
 
     # Compute the rewards for the responses given the prompt.
@@ -76,60 +78,66 @@ async def run_step( self, prompt: str, k: int, timeout: float, name: str, exclud
     for weight_i, reward_fn_i in zip(self.reward_weights, self.reward_functions):
         reward_i = reward_fn_i.apply(prompt, responses, name).to(self.device)
         rewards += weight_i * reward_i
-        if self.config.neuron.log_rewards:     
-            event[ reward_fn_i.name ] = reward_i.tolist()
-        bt.logging.trace( str(reward_fn_i.name), reward_i.tolist() )
-    
+        if not self.config.neuron.disable_log_rewards:
+            event[reward_fn_i.name] = reward_i.tolist()
+        bt.logging.trace(str(reward_fn_i.name), reward_i.tolist())
+
     for masking_fn_i in self.masking_functions:
-        mask_i = masking_fn_i.apply( prompt, responses, name ).to( self.device )
-        rewards *= mask_i
-        if self.config.neuron.log_rewards:   
-            event[ masking_fn_i.name ] = mask_i.tolist()
-        bt.logging.trace( str(masking_fn_i.name), mask_i.tolist() )
+        mask_i = masking_fn_i.apply(prompt, responses, name).to(self.device)
+        rewards *= mask_i  # includes diversity
+        if not self.config.neuron.disable_log_rewards:
+            event[masking_fn_i.name] = mask_i.tolist()
+        bt.logging.trace(str(masking_fn_i.name), mask_i.tolist())
 
     # Train the gating model based on the predicted scores and the actual rewards.
-    gating_scores: torch.FloatTensor = self.gating_model( prompt ).to(self.device)
-    gating_loss: torch.FloatTensor = self.gating_model.backward( scores = gating_scores[uids], rewards = rewards )
+    gating_scores: torch.FloatTensor = self.gating_model(prompt).to(self.device)
+    gating_loss: torch.FloatTensor = self.gating_model.backward(scores=gating_scores[uids], rewards=rewards)
 
     # Find the best completion given the rewards vector.
-    completions: List[str] = [comp.completion for comp in responses ]
-    best:str = completions[ rewards.argmax( dim = 0 )].strip()
+    completions: List[str] = [comp.completion for comp in responses]
+    best: str = completions[rewards.argmax(dim=0)].strip()
 
     # Get completion times
-    completion_times: List[float] = [comp.elapsed_time for comp in responses ]
+    completion_times: List[float] = [comp.elapsed_time for comp in responses]
 
     # Compute forward pass rewards, assumes followup_uids and answer_uids are mutually exclusive.
     # shape: [ metagraph.n ]
-    scattered_rewards: torch.FloatTensor = self.moving_averaged_scores.scatter( 0, uids, rewards ).to(self.device) 
+    scattered_rewards: torch.FloatTensor = self.moving_averaged_scores.scatter(0, uids, rewards).to(self.device)
 
     # Update moving_averaged_scores with rewards produced by this step.
     # shape: [ metagraph.n ]
-    alpha:float = self.config.neuron.moving_average_alpha
-    self.moving_averaged_scores: torch.FloatTensor = alpha * scattered_rewards + (1 - alpha) * self.moving_averaged_scores.to(self.device)
+    alpha: float = self.config.neuron.moving_average_alpha
+    self.moving_averaged_scores: torch.FloatTensor = alpha * scattered_rewards + (1 - alpha) * self.moving_averaged_scores.to(
+        self.device
+    )
 
     # Log the step event.
-    event.update({
-        "block": ttl_get_block( self ),
-        'step_length': time.time() - start_time,
-        'prompt': prompt,
-        'uids': uids.tolist(),
-        'completions': completions,
-        'completion_times': completion_times,
-        'rewards': rewards.tolist(),
-        'gating_loss': gating_loss.item(),
-        'best': best
-    })
-    bt.logging.debug( "event:", str(event) )
-    if not self.config.neuron.dont_save_events: logger.log("EVENTS", "events", **event)
+    event.update(
+        {
+            "block": ttl_get_block(self),
+            "step_length": time.time() - start_time,
+            "prompt": prompt,
+            "uids": uids.tolist(),
+            "completions": completions,
+            "completion_times": completion_times,
+            "rewards": rewards.tolist(),
+            "gating_loss": gating_loss.item(),
+            "best": best,
+        }
+    )
+    bt.logging.debug("event:", str(event))
+    if not self.config.neuron.dont_save_events:
+        logger.log("EVENTS", "events", **event)
 
     # Log the event to wandb.
     wandb_event = EventSchema.from_dict(event, self.config.neuron.log_rewards)
-    if not self.config.wandb.off: self.wandb.log(asdict(wandb_event))
+    if not self.config.wandb.off:
+        self.wandb.log(asdict(wandb_event))
 
     # Return the event.
     return event
 
-    
+
 async def forward(self):
 
     # Obtain a unique context from the dataset.
@@ -137,54 +145,56 @@ async def forward(self):
 
     random_cutoff = random.randint(15, 30)
     # Truncate context to a limited set of sentences.
-    base_text = '.'.join(data.split('.', maxsplit=random_cutoff)[:-1])
+    base_text = ".".join(data.split(".", maxsplit=random_cutoff)[:-1])
     aug_prompt = augment_prompt(base_text)
 
-    # Reset Blacklist reward model 
+    # Reset Blacklist reward model
     self.blacklist.reset()
 
     # Request a summary, given the original context.
-    augment_event = await run_step( 
-        self, 
-        prompt = aug_prompt, 
-        name = 'augment',
-        k = self.config.neuron.followup_sample_size,
-        timeout = self.config.neuron.followup_timeout,
+    augment_event = await run_step(
+        self,
+        prompt=aug_prompt,
+        name="augment",
+        k=self.config.neuron.followup_sample_size,
+        timeout=self.config.neuron.followup_timeout,
     )
-    
-    base_text = augment_event['best']
-    exclude = augment_event['uids']
-    for k in range( self.config.neuron.num_followup_steps ):
+
+    base_text = augment_event["best"]
+    exclude = augment_event["uids"]
+    for k in range(self.config.neuron.num_followup_steps):
 
         # Get a followup question, given the summarized context.
-        prompt = followup_prompt( base_text , i = k)
-        followup_event = await run_step( 
-            self, 
-            prompt = prompt, 
-            name = 'followup' + str(k),
-            k = self.config.neuron.followup_sample_size,
-            timeout = self.config.neuron.followup_timeout,
-            exclude = exclude
+        prompt = followup_prompt(base_text, i=k)
+        followup_event = await run_step(
+            self,
+            prompt=prompt,
+            name="followup" + str(k),
+            k=self.config.neuron.followup_sample_size,
+            timeout=self.config.neuron.followup_timeout,
+            exclude=exclude,
         )
-        exclude += followup_event['uids']
+        exclude += followup_event["uids"]
 
         # Ask the followup question, given the original context.
-        prompt = answer_prompt( base_text, followup_event['best'] )
-        answer_event = await run_step( 
-            self, 
-            prompt = prompt, 
-            name = 'answer' + str(k),
-            k = self.config.neuron.answer_sample_size,
-            timeout = self.config.neuron.answer_timeout,
-            exclude = exclude
+        prompt = answer_prompt(base_text, followup_event["best"])
+        answer_event = await run_step(
+            self,
+            prompt=prompt,
+            name="answer" + str(k),
+            k=self.config.neuron.answer_sample_size,
+            timeout=self.config.neuron.answer_timeout,
+            exclude=exclude,
         )
-        exclude += answer_event['uids']
-        
-        self.blacklist.question_blacklist.append(followup_event['best'])
-        self.blacklist.answer_blacklist.append(answer_event['best'])
+        exclude += answer_event["uids"]
+
+        self.blacklist.question_blacklist.append(followup_event["best"])
+        self.blacklist.answer_blacklist.append(answer_event["best"])
 
         if k == 0:
             # Extend the base text with the best answer.
-            base_text = base_text + '\nPrevious Question \nQuestion:' + followup_event['best'] + '\nAnswer:' + answer_event['best']
+            base_text = (
+                base_text + "\nPrevious Question \nQuestion:" + followup_event["best"] + "\nAnswer:" + answer_event["best"]
+            )
         else:
-            base_text = base_text + '\nQuestion:' + followup_event['best'] + '\nAnswer:' + answer_event['best']
+            base_text = base_text + "\nQuestion:" + followup_event["best"] + "\nAnswer:" + answer_event["best"]

--- a/openvalidators/neuron.py
+++ b/openvalidators/neuron.py
@@ -42,7 +42,7 @@ from openvalidators.reward import (
     DahoasRewardModel,
     DiversityRewardModel,
     PromptRewardModel,
-    RewardModelType
+    RewardModelType,
 )
 
 
@@ -135,46 +135,65 @@ class neuron:
             ]
             bt.logging.debug(str(self.reward_functions))
         else:
-            self.reward_weights = torch.tensor([
-                self.config.reward.rlhf_weight, self.config.reward.reciprocate_weight, self.config.reward.dahoas_weight,
-                self.config.reward.diversity_weight, self.config.reward.prompt_based_weight
-            ], dtype=torch.float32).to(self.device)
+            self.reward_weights = torch.tensor(
+                [
+                    self.config.reward.rlhf_weight,
+                    self.config.reward.reciprocate_weight,
+                    self.config.reward.dahoas_weight,
+                    self.config.reward.diversity_weight,
+                    self.config.reward.prompt_based_weight,
+                ],
+                dtype=torch.float32,
+            ).to(self.device)
 
             # Ensure reward function weights sum to 1.
             if self.reward_weights.sum() != 1:
-                message = f"Reward function weights do not sum to 1 (Current sum: {self.reward_weights.sum()}.)" \
-                          f"Check your reward config file at `reward/config.py` or ensure that all your cli reward flags sum to 1."
+                message = (
+                    f"Reward function weights do not sum to 1 (Current sum: {self.reward_weights.sum()}.)"
+                    f"Check your reward config file at `reward/config.py` or ensure that all your cli reward flags sum to 1."
+                )
                 bt.logging.error(message)
                 raise Exception(message)
 
             self.reward_functions = [
-                OpenAssistantRewardModel(device=self.device) if self.config.reward.rlhf_weight > 0
-                    else MockRewardModel(RewardModelType.rlhf.value),
-                ReciprocateRewardModel(device=self.device) if self.config.reward.reciprocate_weight > 0
-                    else MockRewardModel(RewardModelType.reciprocate.value),
-                DahoasRewardModel(path=self.config.neuron.full_path, device=self.device) if self.config.reward.dahoas_weight > 0
-                    else MockRewardModel(RewardModelType.dahoas.value),
-                DiversityRewardModel(device=self.device) if self.config.reward.diversity_weight > 0
-                    else MockRewardModel(RewardModelType.diversity.value),
-                PromptRewardModel(device=self.device) if self.config.reward.prompt_based_weight > 0
-                    else MockRewardModel(RewardModelType.prompt.value),
+                OpenAssistantRewardModel(device=self.device)
+                if self.config.reward.rlhf_weight > 0
+                else MockRewardModel(RewardModelType.rlhf.value),
+                ReciprocateRewardModel(device=self.device)
+                if self.config.reward.reciprocate_weight > 0
+                else MockRewardModel(RewardModelType.reciprocate.value),
+                DahoasRewardModel(path=self.config.neuron.full_path, device=self.device)
+                if self.config.reward.dahoas_weight > 0
+                else MockRewardModel(RewardModelType.dahoas.value),
+                PromptRewardModel(device=self.device)
+                if self.config.reward.prompt_based_weight > 0
+                else MockRewardModel(RewardModelType.prompt.value),
             ]
 
             if len(self.reward_functions) != len(self.reward_weights):
-                message = f"Length of reward function weights and reward functions do not match. " \
-                          f"Reward functions: {len(self.reward_functions)}, Reward weights: {len(self.reward_weights)}"
+                message = (
+                    f"Length of reward function weights and reward functions do not match. "
+                    f"Reward functions: {len(self.reward_functions)}, Reward weights: {len(self.reward_weights)}"
+                )
 
                 bt.logging.error(message)
                 raise Exception(message)
-            
-            self.blacklist = Blacklist() if not self.config.neuron.blacklist_off else MockRewardModel(RewardModelType.blacklist.value)
+
+            self.blacklist = (
+                Blacklist() if not self.config.neuron.blacklist_off else MockRewardModel(RewardModelType.blacklist.value)
+            )
 
             self.masking_functions = [
                 self.blacklist,
-                BertRelevanceRewardModel(device=self.device) if not self.config.neuron.relevance_off
-                    else MockRewardModel(RewardModelType.relevance.value),
-                NSFWRewardModel(device=self.device) if not self.config.neuron.nsfw_off
-                    else MockRewardModel(RewardModelType.nsfw.value),
+                BertRelevanceRewardModel(device=self.device)
+                if not self.config.neuron.relevance_off
+                else MockRewardModel(RewardModelType.relevance.value),
+                DiversityRewardModel(device=self.device)
+                if self.config.reward.diversity_weight > 0
+                else MockRewardModel(RewardModelType.diversity.value),
+                NSFWRewardModel(device=self.device)
+                if not self.config.neuron.nsfw_off
+                else MockRewardModel(RewardModelType.nsfw.value),
             ]
             bt.logging.debug(str(self.reward_functions))
 

--- a/openvalidators/neuron.py
+++ b/openvalidators/neuron.py
@@ -140,7 +140,6 @@ class neuron:
                     self.config.reward.rlhf_weight,
                     self.config.reward.reciprocate_weight,
                     self.config.reward.dahoas_weight,
-                    self.config.reward.diversity_weight,
                     self.config.reward.prompt_based_weight,
                 ],
                 dtype=torch.float32,

--- a/openvalidators/neuron.py
+++ b/openvalidators/neuron.py
@@ -188,7 +188,7 @@ class neuron:
                 if not self.config.neuron.relevance_off
                 else MockRewardModel(RewardModelType.relevance.value),
                 DiversityRewardModel(device=self.device)
-                if not self.config.reward.diversity_off
+                if not self.config.neuron.diversity_off
                 else MockRewardModel(RewardModelType.diversity.value),
                 NSFWRewardModel(device=self.device)
                 if not self.config.neuron.nsfw_off

--- a/openvalidators/neuron.py
+++ b/openvalidators/neuron.py
@@ -188,7 +188,7 @@ class neuron:
                 if not self.config.neuron.relevance_off
                 else MockRewardModel(RewardModelType.relevance.value),
                 DiversityRewardModel(device=self.device)
-                if self.config.reward.diversity_weight > 0
+                if not self.config.reward.diversity_off
                 else MockRewardModel(RewardModelType.diversity.value),
                 NSFWRewardModel(device=self.device)
                 if not self.config.neuron.nsfw_off

--- a/openvalidators/reward/config.py
+++ b/openvalidators/reward/config.py
@@ -38,5 +38,4 @@ class DefaultRewardFrameworkConfig:
     rlhf_model_weight: float = 0.6
     reciprocate_model_weight: float = 0.4
     dahoas_model_weight: float = 0
-    diversity_model_weight: float = 0
     prompt_model_weight: float = 0

--- a/openvalidators/reward/config.py
+++ b/openvalidators/reward/config.py
@@ -35,8 +35,8 @@ class DefaultRewardFrameworkConfig:
     """Reward framework default configuration.
     Note: All the weights should add up to 1.0.
     """
-    rlhf_model_weight: float = 0.5
-    reciprocate_model_weight: float = 0.3
+    rlhf_model_weight: float = 0.6
+    reciprocate_model_weight: float = 0.4
     dahoas_model_weight: float = 0
-    diversity_model_weight: float = 0.2
+    diversity_model_weight: float = 0
     prompt_model_weight: float = 0

--- a/openvalidators/utils.py
+++ b/openvalidators/utils.py
@@ -118,6 +118,8 @@ def resync_metagraph(self):
 
         # Update the hotkeys.
         self.hotkeys = copy.deepcopy(self.metagraph.hotkeys)
+    
+    
 
 
 def resync_linear_layer(
@@ -193,6 +195,12 @@ def save_state(self):
         gating_model_file_path = f"{self.config.neuron.full_path}/{gating_model_name}_gating_linear_layer.pth"
         torch.save(gating_model_linear_layer_dict, gating_model_file_path)
 
+        if not self.config.wandb.off:
+            wandb.log({
+                "step": self.step,
+                "block": ttl_get_block(self),
+                **neuron_state_dict                
+            })                
         if not self.config.wandb.off and self.config.wandb.track_gating_model:
             model_artifact = wandb.Artifact(f"{gating_model_name}_gating_linear_layer", type="model")
             model_artifact.add_file(gating_model_file_path)

--- a/openvalidators/weights.py
+++ b/openvalidators/weights.py
@@ -51,9 +51,6 @@ def set_weights(self):
     bt.logging.trace("processed_weights", processed_weights)
     bt.logging.trace("processed_weight_uids", processed_weight_uids)
 
-    if not self.config.wandb.off:
-        wandb.log({"set_weights": list(zip(processed_weight_uids.tolist(), processed_weights.tolist()))})
-
     # Set the weights on chain via our subtensor connection.
     self.subtensor.set_weights(
         wallet=self.wallet,

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -49,7 +49,7 @@ class EventTestCase(unittest.TestCase):
 
         # Act
         with patch('bittensor.logging.warning') as mock_warning:
-            event = EventSchema.from_dict(event_dict, should_log_rewards=True)
+            event = EventSchema.from_dict(event_dict, disable_log_rewards=True)
             mock_warning.assert_not_called()
 
         # Assert
@@ -85,7 +85,7 @@ class EventTestCase(unittest.TestCase):
 
         # Act
         with patch('bittensor.logging.warning') as mock_warning:
-            event = EventSchema.from_dict(event_dict, should_log_rewards=False)
+            event = EventSchema.from_dict(event_dict, disable_log_rewards=False)
             mock_warning.assert_not_called()
 
         # Assert: Check that all columns that were logged are correctly converted
@@ -124,7 +124,7 @@ class EventTestCase(unittest.TestCase):
 
         # Act
         with patch('bittensor.logging.warning') as mock_warning:
-            event = EventSchema.from_dict(event_dict, should_log_rewards=True)
+            event = EventSchema.from_dict(event_dict, disable_log_rewards=True)
             # Assert: Check that all columns that are not logged in the dict are logged as warnings
             self.assertEqual(mock_warning.call_count, len(not_logged_columns))
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -85,7 +85,7 @@ class EventTestCase(unittest.TestCase):
 
         # Act
         with patch('bittensor.logging.warning') as mock_warning:
-            event = EventSchema.from_dict(event_dict, disable_log_rewards=False)
+            event = EventSchema.from_dict(event_dict, disable_log_rewards=True)
             mock_warning.assert_not_called()
 
         # Assert: Check that all columns that were logged are correctly converted
@@ -124,7 +124,7 @@ class EventTestCase(unittest.TestCase):
 
         # Act
         with patch('bittensor.logging.warning') as mock_warning:
-            event = EventSchema.from_dict(event_dict, disable_log_rewards=True)
+            event = EventSchema.from_dict(event_dict, disable_log_rewards=False)
             # Assert: Check that all columns that are not logged in the dict are logged as warnings
             self.assertEqual(mock_warning.call_count, len(not_logged_columns))
 


### PR DESCRIPTION
Tracked [experiment](https://wandb.ai/opentensor-dev/openvalidators/runs/0hpv7166?workspace=user-opentensor-steffen) with frequent weight and hotkey logging
Changes:

- Move diversity model from rewards (weighted sum) to filter models (products) so it has more power over final score
- Log all rewards by default and rename to `neuron.disable_log_rewards`
- Update `EventSchema.to_dict` to reflect these changes