### PR TITLE
fix wandb weights logging 

### DIFF
--- a/openvalidators/utils.py
+++ b/openvalidators/utils.py
@@ -182,7 +182,7 @@ def save_state(self):
     bt.logging.info("save_state()")
     try:
         neuron_state_dict = {
-            "neuron_weights": self.moving_averaged_scores,
+            "neuron_weights": self.moving_averaged_scores.to('cpu').tolist(),
             "neuron_hotkeys": self.hotkeys,
         }
         torch.save(neuron_state_dict, f"{self.config.neuron.full_path}/model.torch")
@@ -202,7 +202,7 @@ def save_state(self):
                 "step": self.step,
                 "block": ttl_get_block(self),
                 **neuron_state_dict                
-            })                
+            })
         if not self.config.wandb.off and self.config.wandb.track_gating_model:
             model_artifact = wandb.Artifact(f"{gating_model_name}_gating_linear_layer", type="model")
             model_artifact.add_file(gating_model_file_path)


### PR DESCRIPTION
## Problem:
The current implementation that logs weights to wandb gets converted to a wandb histogram of 32 bins in the run dataset, complicating individual uid-weight tracking.

## Solution:
It seems that this is the default behavior of wandb while working with raw tensors, converting the tensor to a list does the job of logging all the 1024 weights uids correctly.

> Note: Unfortunately wandb [histograms are limited to 512 bins max](https://github.com/wandb/wandb/blob/8e00f0aec90024de8a8a601b0efdbd63d1acb5aa/wandb/sdk/data_types/histogram.py#L40C13-L40C13)

Example run: 
https://wandb.ai/opentensor-dev/openvalidators/runs/ahics286