### PR TITLE
pull num_uids from subtensor

### DIFF
--- a/openvalidators/gating.py
+++ b/openvalidators/gating.py
@@ -52,8 +52,7 @@ class BaseGatingModel(torch.nn.Module, ABC):
         parser.add_argument(
             "--gating.num_uids",
             type=int,
-            default=1024,
-            help="Number of uids to gate on",
+            help="Number of uids to gate on. Default is pulled from subtensor directly",
         )
         parser.add_argument(
             "--gating.learning_rate",

--- a/openvalidators/neuron.py
+++ b/openvalidators/neuron.py
@@ -108,6 +108,8 @@ class neuron:
 
         # Init the gating model which learns which miners to select for each query.
         bt.logging.debug("loading", "gating_model")
+        if not self.config.gating.num_uids:
+            self.config.gating.num_uids = self.subtensor.query_subtensor("MaxAllowedUids", params=[self.config.netuid])        
         if self.config.neuron.mock_gating_model:
             self.gating_model = MockGatingModel(self.metagraph.n.item())
         elif self.config.neuron.use_custom_gating_model:


### PR DESCRIPTION
This eliminates guesswork in determining how many UIDs to initialize the gating model with per subnet.