### PR TITLE
Softmax reward model outputs

### DIFF
--- a/openvalidators/reward/open_assistant.py
+++ b/openvalidators/reward/open_assistant.py
@@ -41,3 +41,7 @@ class OpenAssistantRewardModel( BaseRewardModel ):
         
     def get_rewards( self, prompt: str, completions: List[str], name: str ) -> torch.FloatTensor:
         return torch.tensor( [self.reward_single( prompt, completion, name ) for completion in completions], dtype=torch.float32).to(self.device)
+
+    def normalize_rewards( self, rewards: torch.FloatTensor ) -> torch.FloatTensor:
+        # softmax rewards (logits) from reward model.
+        return rewards.softmax(dim=0)

--- a/openvalidators/reward/reciprocate.py
+++ b/openvalidators/reward/reciprocate.py
@@ -49,4 +49,7 @@ class ReciprocateRewardModel( BaseRewardModel ):
         
     def get_rewards( self, prompt: str, completions: List[str], name: str ) -> torch.FloatTensor:
         return torch.tensor( [self.reward( prompt, completion, name ) for completion in completions], dtype=torch.float32).to(self.device)
-        
+
+    def normalize_rewards(self, rewards: torch.FloatTensor) -> torch.FloatTensor:
+        # softmax rewards (logits) from reward model.
+        return rewards.softmax(dim=0)

--- a/openvalidators/reward/reward.py
+++ b/openvalidators/reward/reward.py
@@ -96,7 +96,7 @@ class BaseRewardModel:
         # Reward each completion.
         successful_rewards = self.get_rewards( prompt, successful_completions, name )
 
-        # Softmax rewards across samples.
+        # Perform a longer-term standardization across samples.
         successful_rewards = self.normalize_rewards( successful_rewards )
 
         # Init zero rewards for all calls.


### PR DESCRIPTION
Logits appear to be the outputs of both open_assistant and reciprocate models, but then requires softmax treatment for correct interpretation. Current standardization can then be removed, due to softmax itself just having a relative interpretation and always summing to 1. This change is intended to improve the interpretation of these reward model outputs.