### PR TITLE
Hotfix: Device errors

### DIFF
--- a/openvalidators/forward.py
+++ b/openvalidators/forward.py
@@ -117,7 +117,7 @@ async def run_step(self, prompt: str, k: int, timeout: float, name: str, exclude
             "block": ttl_get_block(self),
             "step_length": time.time() - start_time,
             "prompt": prompt,
-            "uids": uids.tolist(),
+            "uids": uids.cpu().tolist(),
             "completions": completions,
             "completion_times": completion_times,
             "rewards": rewards.tolist(),

--- a/openvalidators/forward.py
+++ b/openvalidators/forward.py
@@ -42,15 +42,24 @@ def get_random_uids(self, k: int, exclude: List[int] = None) -> torch.LongTensor
         If `k` is larger than the number of available `uids`, set `k` to the number of available `uids`.
     """
     candidate_uids = []
+    avail_uids = []
 
     for uid in range(self.metagraph.n.item()):
         uid_is_available = check_uid_availability(self.metagraph, uid, self.config.neuron.vpermit_tao_limit)
         uid_is_not_excluded = exclude is None or uid not in exclude
 
-        if uid_is_available and uid_is_not_excluded:
-            candidate_uids.append(uid)
+        if uid_is_available:
+            avail_uids.append(uid)
+            if uid_is_not_excluded:
+                candidate_uids.append(uid)
 
-    available_uids = torch.tensor(candidate_uids, dtype=torch.int64).to(self.device)
+    # Check if candidate_uids contain enough for querying, if not grab all avaliable uids
+    if len(candidate_uids) > k:
+        available_uids = torch.tensor(candidate_uids, dtype=torch.int64).to(self.device)
+    else:
+        available_uids = torch.tensor(avail_uids, dtype=torch.int64).to(self.device)
+
+
     uids = torch.tensor(random.sample(available_uids.tolist(), k), dtype=torch.int64)
     return uids
 

--- a/openvalidators/forward.py
+++ b/openvalidators/forward.py
@@ -110,14 +110,15 @@ async def run_step(self, prompt: str, k: int, timeout: float, name: str, exclude
     self.moving_averaged_scores: torch.FloatTensor = alpha * scattered_rewards + (1 - alpha) * self.moving_averaged_scores.to(
         self.device
     )
-
+    import pdb
+    pdb.set_trace()
     # Log the step event.
     event.update(
         {
             "block": ttl_get_block(self),
             "step_length": time.time() - start_time,
             "prompt": prompt,
-            "uids": uids.cpu().tolist(),
+            "uids": uids.tolist(),
             "completions": completions,
             "completion_times": completion_times,
             "rewards": rewards.tolist(),

--- a/openvalidators/forward.py
+++ b/openvalidators/forward.py
@@ -110,8 +110,7 @@ async def run_step(self, prompt: str, k: int, timeout: float, name: str, exclude
     self.moving_averaged_scores: torch.FloatTensor = alpha * scattered_rewards + (1 - alpha) * self.moving_averaged_scores.to(
         self.device
     )
-    import pdb
-    pdb.set_trace()
+
     # Log the step event.
     event.update(
         {

--- a/openvalidators/gating.py
+++ b/openvalidators/gating.py
@@ -228,7 +228,7 @@ class SentenceEmbedGatingModel(BaseGatingModel):
             config = SentenceEmbedGatingModel.config()
         if model_name is not None:
             config.gating.model_name = model_name
-        config.gating.num_uids = num_uids if num_uids is not None else metagraph.n
+        config.gating.num_uids = num_uids if num_uids is not None else config.gating.num_uids
         self.config = config
         self.num_uids = config.gating.num_uids
         self.device = torch.device(self.config.neuron.device)

--- a/openvalidators/gating.py
+++ b/openvalidators/gating.py
@@ -137,7 +137,7 @@ class GatingModel(BaseGatingModel):
             config = GatingModel.config()
         if model_name is not None:
             config.gating.model_name = model_name
-        config.gating.num_uids = num_uids if num_uids is not None else metagraph.n
+        config.gating.num_uids = num_uids if num_uids is not None else config.gating.num_uids
         self.config = config
         self.num_uids = config.gating.num_uids
         self.device = torch.device(self.config.neuron.device)

--- a/openvalidators/reward/diversity.py
+++ b/openvalidators/reward/diversity.py
@@ -87,6 +87,8 @@ class DiversityRewardModel( BaseRewardModel ):
         return sentence_embeddings
 
     def get_rewards( self, prompt: str, completions: List[str], name: str ) -> torch.FloatTensor:
+
+        # Check if completions are empty, return 0 if so
         if len(completions) == 0:
             return torch.tensor([])
         

--- a/openvalidators/reward/reward.py
+++ b/openvalidators/reward/reward.py
@@ -76,7 +76,7 @@ class BaseRewardModel:
             self.count = min(self.count_limit, self.count + new_count)
 
         # Standardize the rewards using the updated mean and variance.
-        rewards = rewards - self.mean
+        rewards = rewards - self.mean.to(self.device)
         if self.var > 0:
             rewards /= torch.sqrt(self.var)
         # Scale the standardized rewards to the range [0, 1] using the error function as a cumulative distribution function (CDF).

--- a/openvalidators/reward/reward.py
+++ b/openvalidators/reward/reward.py
@@ -51,9 +51,7 @@ class BaseRewardModel:
             - This function uses Welford's online algorithm to update the mean and variance.
             - It standardizes the reward values using the updated mean and variance.
             - It then scales the standardized values to the 0-1 range using the error function (erf) as a CDF.
-        """
-        rewards = rewards.detach().cpu()
-        
+        """        
         # Get the number of rewards (successful responses).
         new_count = rewards.numel()
 

--- a/openvalidators/reward/reward.py
+++ b/openvalidators/reward/reward.py
@@ -52,6 +52,8 @@ class BaseRewardModel:
             - It standardizes the reward values using the updated mean and variance.
             - It then scales the standardized values to the 0-1 range using the error function (erf) as a CDF.
         """        
+        rewards = rewards.detach().cpu()
+
         # Get the number of rewards (successful responses).
         new_count = rewards.numel()
 
@@ -88,6 +90,7 @@ class BaseRewardModel:
         """ Applies the reward model across each call. Unsuccessful responses are zeroed.
         """
         # Get indices of correctly responding calls.
+        
         successful_completions_indices: List[int] = [ idx for idx, resp in enumerate(responses) if resp.is_success ]
 
         # Get all completions from responding calls.

--- a/openvalidators/reward/reward.py
+++ b/openvalidators/reward/reward.py
@@ -52,6 +52,8 @@ class BaseRewardModel:
             - It standardizes the reward values using the updated mean and variance.
             - It then scales the standardized values to the 0-1 range using the error function (erf) as a CDF.
         """
+        rewards = rewards.detach().cpu()
+        
         # Get the number of rewards (successful responses).
         new_count = rewards.numel()
 
@@ -76,7 +78,7 @@ class BaseRewardModel:
             self.count = min(self.count_limit, self.count + new_count)
 
         # Standardize the rewards using the updated mean and variance.
-        rewards = rewards - self.mean.to(self.device)
+        rewards = rewards - self.mean
         if self.var > 0:
             rewards /= torch.sqrt(self.var)
         # Scale the standardized rewards to the range [0, 1] using the error function as a cumulative distribution function (CDF).


### PR DESCRIPTION
- rewards should be detached and sent to cpu during normalization
- this prevents a device issue when running a seperate gpu
- `--gating.num_uids` was set as metagraph.n instead of the command line value