### PR TITLE
[hotfix] bump datasets pin to fix python compat

### DIFF
--- a/openvalidators/__init__.py
+++ b/openvalidators/__init__.py
@@ -28,6 +28,6 @@ from . import utils
 from . import weights
 from . import event
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bittensor==5.2.0
 transformers<=4.28.0 
 wandb==0.15.3
-datasets==2.12.0
+datasets>=2.14.0
 plotly==5.14.1
 networkx==3.1
 scipy==1.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bittensor==5.2.1
+bittensor>=5.2.1,<5.3.0
 transformers<=4.28.0 
 wandb==0.15.3
 datasets>=2.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bittensor==5.2.0
+bittensor==5.2.1
 transformers<=4.28.0 
 wandb==0.15.3
 datasets>=2.14.0


### PR DESCRIPTION
This fixes a new issue (3 days old) with python updating multiprocessing for python 3.11 support.   Borks all fresh python (any version)  installs of bittensor as datasets was pinned at a lower version.

Does 2 things:
- datasets pinned to `2.14.0`.
- bittensor version bump to `5.2.1` (hotfix for this issue)

See bittensor release [5.2.1](https://github.com/opentensor/bittensor/tree/release/5.2.1)
https://github.com/opentensor/bittensor/pull/1468