### PR TITLE
HOTFIX: create and serve the axon at startup

### DIFF
--- a/openvalidators/neuron.py
+++ b/openvalidators/neuron.py
@@ -127,6 +127,13 @@ class neuron:
             self.gating_model = GatingModel(metagraph=self.metagraph, config=self.config).to(self.device)
         bt.logging.debug(str(self.gating_model))
 
+        bt.logging.debug('serving ip to chain...')
+        axon = bt.axon( 
+            wallet=self.wallet, metagraph=self.metagraph, config=self.config 
+         ).serve()
+
+        del axon
+
         # Dendrite pool for querying the network during  training.
         bt.logging.debug("loading", "dendrite_pool")
         if self.config.neuron.mock_dendrite_pool:

--- a/openvalidators/neuron.py
+++ b/openvalidators/neuron.py
@@ -130,7 +130,7 @@ class neuron:
         bt.logging.debug('serving ip to chain...')
         axon = bt.axon( 
             wallet=self.wallet, metagraph=self.metagraph, config=self.config 
-         ).serve()
+         )
 
         del axon
 


### PR DESCRIPTION
the validator does not post their IP to the chain, which can lead to 0.0.0.0 being listed as the IP on the chain. Here is a hotfix that creates the axon and serves it, then deletes the axon.