### PR TITLE
Save/load `historic_embeddings` to/from disk

### DIFF
--- a/openvalidators/neuron.py
+++ b/openvalidators/neuron.py
@@ -201,7 +201,7 @@ class neuron:
                 RelevanceRewardModel(device=self.device) if not self.config.neuron.relevance_off
                 else MockRewardModel(RewardModelType.relevance.value)
             )
-            diversity_model = (
+            self.diversity_model = (
                 DiversityRewardModel(device=self.device) if not self.config.neuron.diversity_off
                 else MockRewardModel(RewardModelType.diversity.value)
             )
@@ -210,7 +210,7 @@ class neuron:
                 else MockRewardModel(RewardModelType.nsfw.value)              
             )
 
-            self.masking_functions = [self.blacklist, task_validator, relevance_model, diversity_model, nsfw_model]
+            self.masking_functions = [self.blacklist, task_validator, relevance_model, self.diversity_model, nsfw_model]
             bt.logging.debug(str(self.reward_functions))
             bt.logging.debug(str(self.masking_functions))
 

--- a/openvalidators/utils.py
+++ b/openvalidators/utils.py
@@ -226,7 +226,7 @@ def save_state(self):
         torch.save(diversity_model_dict, diversity_model_file_path)
         bt.logging.success(
             prefix="Saved diversity model",
-            sufix=f"<blue>{diversity_model_file_path}</blue> [{list(self.diversity_model.historic_embeddings.shape)}]",
+            sufix=f"<blue>{diversity_model_file_path}</blue> {list(self.diversity_model.historic_embeddings.shape)}",
         )
     except Exception as e:
         bt.logging.warning(f"Failed to save diversity model with error: {e}")
@@ -258,7 +258,7 @@ def load_state(self):
         self.diversity_model.historic_embeddings = diversity_model_dict["historic_embeddings"]
         bt.logging.success(
             prefix="Reloaded diversity model",
-            sufix=f"<blue>{diversity_model_file_path}</blue> [{list(self.diversity_model.historic_embeddings.shape)}]",
+            sufix=f"<blue>{diversity_model_file_path}</blue> {list(self.diversity_model.historic_embeddings.shape)}",
         )
     except Exception as e:
         bt.logging.warning(f"Failed to load diversity model with error: {e}")

--- a/openvalidators/utils.py
+++ b/openvalidators/utils.py
@@ -241,8 +241,9 @@ def load_state(self):
     try:
         state_dict = torch.load(f"{self.config.neuron.full_path}/model.torch")
         # Check for nans in saved state dict
-        if not torch.isnan(state_dict["neuron_weights"]).any():        
-            self.moving_averaged_scores = state_dict["neuron_weights"].clone().detach()
+        neuron_weights = torch.tensor(state_dict["neuron_weights"])
+        if not torch.isnan(neuron_weights).any():
+            self.moving_averaged_scores = neuron_weights
         self.hotkeys = state_dict["neuron_hotkeys"]
         bt.logging.success(
             prefix="Reloaded model",

--- a/openvalidators/utils.py
+++ b/openvalidators/utils.py
@@ -201,6 +201,15 @@ def save_state(self):
         gating_model_file_path = f"{self.config.neuron.full_path}/{gating_model_name}_gating_linear_layer.pth"
         torch.save(gating_model_linear_layer_dict, gating_model_file_path)
 
+        # Save diversity model.
+        diversity_model_dict = {"historic_embeddings": self.diversity_model.historic_embeddings}
+        diversity_model_file_path = f"{self.config.neuron.full_path}/diversity_model.pth"
+        torch.save(diversity_model_dict, diversity_model_file_path)
+        bt.logging.success(
+            prefix="Saved diversity model",
+            sufix=f"<blue>{diversity_model_file_path}</blue> [{self.diversity_model.historic_embeddings.shape}]",
+        )
+
         if not self.config.wandb.off:
             wandb.log({
                 "step": self.step,
@@ -234,5 +243,15 @@ def load_state(self):
             prefix="Reloaded model",
             sufix=f"<blue>{ self.config.neuron.full_path }/model.torch</blue>",
         )
+
+        # Load diversity model.
+        diversity_model_file_path = f"{self.config.neuron.full_path}/diversity_model.pth"
+        diversity_model_dict = torch.load(diversity_model_file_path)
+        self.diversity_model.historic_embeddings = diversity_model_dict["historic_embeddings"]
+        bt.logging.success(
+            prefix="Reloaded diversity model",
+            sufix=f"<blue>{diversity_model_file_path}</blue> [{self.diversity_model.historic_embeddings.shape}]",
+        )
+
     except Exception as e:
         bt.logging.warning(f"Failed to load model with error: {e}")

--- a/openvalidators/utils.py
+++ b/openvalidators/utils.py
@@ -243,7 +243,7 @@ def load_state(self):
         # Check for nans in saved state dict
         neuron_weights = torch.tensor(state_dict["neuron_weights"])
         if not torch.isnan(neuron_weights).any():
-            self.moving_averaged_scores = neuron_weights
+            self.moving_averaged_scores = neuron_weights.to(self.device)
         self.hotkeys = state_dict["neuron_hotkeys"]
         bt.logging.success(
             prefix="Reloaded model",

--- a/openvalidators/utils.py
+++ b/openvalidators/utils.py
@@ -226,7 +226,7 @@ def save_state(self):
         torch.save(diversity_model_dict, diversity_model_file_path)
         bt.logging.success(
             prefix="Saved diversity model",
-            sufix=f"<blue>{diversity_model_file_path}</blue> [{self.diversity_model.historic_embeddings.shape}]",
+            sufix=f"<blue>{diversity_model_file_path}</blue> [{list(self.diversity_model.historic_embeddings.shape)}]",
         )
     except Exception as e:
         bt.logging.warning(f"Failed to save diversity model with error: {e}")
@@ -258,7 +258,7 @@ def load_state(self):
         self.diversity_model.historic_embeddings = diversity_model_dict["historic_embeddings"]
         bt.logging.success(
             prefix="Reloaded diversity model",
-            sufix=f"<blue>{diversity_model_file_path}</blue> [{self.diversity_model.historic_embeddings.shape}]",
+            sufix=f"<blue>{diversity_model_file_path}</blue> [{list(self.diversity_model.historic_embeddings.shape)}]",
         )
     except Exception as e:
         bt.logging.warning(f"Failed to load diversity model with error: {e}")

--- a/openvalidators/utils.py
+++ b/openvalidators/utils.py
@@ -221,7 +221,7 @@ def save_state(self):
 
     try:
         # Save diversity model.
-        diversity_model_dict = {"historic_embeddings": self.diversity_model.historic_embeddings}
+        diversity_model_dict = {"historic_embeddings": self.diversity_model.historic_embeddings.to('cpu')}
         diversity_model_file_path = f"{self.config.neuron.full_path}/diversity_model.pth"
         torch.save(diversity_model_dict, diversity_model_file_path)
         bt.logging.success(
@@ -256,7 +256,7 @@ def load_state(self):
         # Load diversity model.
         diversity_model_file_path = f"{self.config.neuron.full_path}/diversity_model.pth"
         diversity_model_dict = torch.load(diversity_model_file_path)
-        self.diversity_model.historic_embeddings = diversity_model_dict["historic_embeddings"]
+        self.diversity_model.historic_embeddings = diversity_model_dict["historic_embeddings"].to(self.device)
         bt.logging.success(
             prefix="Reloaded diversity model",
             sufix=f"<blue>{diversity_model_file_path}</blue> {list(self.diversity_model.historic_embeddings.shape)}",


### PR DESCRIPTION
### Save/load `historic_embeddings` to/from disk

- Periodically saves `historic_embeddings` to disk via `save_state`.
- 15500 (history range) x 768 (embedding) x 32 bits = 47 MB (projected max size)
- Loads `historic_embeddings` from disk via `load_state` upon validator start.
- Fixes model load `neuron_weights` tensorization.