### PR TITLE
Need to use print exception instead

### DIFF
--- a/openvalidators/run.py
+++ b/openvalidators/run.py
@@ -17,7 +17,7 @@
 
 import asyncio
 import bittensor as bt
-from traceback import print_exc
+from traceback import print_exception
 
 from openvalidators.forward import forward
 from openvalidators.utils import should_checkpoint, checkpoint, should_reinit_wandb, reinit_wandb, load_state, save_state
@@ -58,4 +58,4 @@ def run(self):
 
     except Exception as e:
         bt.logging.error("Error in training loop", str(e))
-        bt.logging.debug(print_exc(e))
+        bt.logging.debug(print_exception(value=e))

--- a/scripts/data_collector.py
+++ b/scripts/data_collector.py
@@ -22,7 +22,7 @@ import pandas as pd
 import openvalidators
 import os
 from analysis.utils import get_runs, download_data
-from traceback import print_exc
+from traceback import print_exception
 from typing import List
 from data_formatter import create_json_dataset, create_csv_dataset, create_openai_dataset
 
@@ -170,4 +170,4 @@ if __name__ == '__main__':
             )
     except Exception as e:
         bt.logging.error("Error in training loop", str(e))
-        bt.logging.debug(print_exc(e))
+        bt.logging.debug(print_exception(value=e))


### PR DESCRIPTION
This switches from `print_exc` to `print_exception` due to incorrect passing of args.  
An alternative is `print_exc()` with no argument. 