### PR TITLE
fix print_exception function call

### DIFF
--- a/openvalidators/run.py
+++ b/openvalidators/run.py
@@ -58,4 +58,4 @@ def run(self):
 
     except Exception as e:
         bt.logging.error("Error in training loop", str(e))
-        bt.logging.debug(print_exception(value=e))
+        bt.logging.debug(print_exception(type(err), err, err.__traceback__))


### PR DESCRIPTION
The `print_exception` was throwing an exception since we were defining a named parameter out of order. I might be wrong in this one but afaik, when we are using named parameters, we need to respect their order, meaning that if we define the second named parameter of a function, the first one needs to be declared if it doesn't have a default value.

In this case, the function signature of `print_exception` is:
```python
def print_exception(etype, value, tb, limit=None, file=None, chain=True):
``` 

Since we were defining the `value` parameter explicitly, we must define `etype` param as well.

The fix bellow defines the `etype`, `value` and `tb` implicitly so this LOC doesn't throw more exceptions.

Closes issue #145 